### PR TITLE
sqrt 計算時に 0.01 が加算される問題の修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
                     return decimalPointCalculate(f1 / f2, decimalPoint)
                 case 'sqrt':
                     // return decimalPointCalculate(Math.sqrt(f1), decimalPoint)
-                    return decimalPointCalculate(Math.sqrt(f1) + 0.01, decimalPoint)
+                    return decimalPointCalculate(Math.sqrt(f1), decimalPoint)
                 case 'square':
                     return decimalPointCalculate(f1 * f1, decimalPoint)
                 default :


### PR DESCRIPTION
fix #5 

## 変更後の振る舞い
* 〜したら
平方根を計算したら
* 〜になる
正しく計算される

## 変更前の振る舞い
* 〜したら
平方根を計算したら
* 〜になる
0.01 が加算された結果となる
